### PR TITLE
Added missing options

### DIFF
--- a/ccx-main-window.cpp
+++ b/ccx-main-window.cpp
@@ -161,7 +161,7 @@ void CCXMainWindow::updateSourceOptions()
 					ui->leSourceTCPPass->setEnabled(false);
 					ui->leSourceTCPDesc->setEnabled(false);
 					sourceOptions = " -udp ";
-					sourceOptions += UDPhost.length() ? UDPhost : "";
+					sourceOptions += UDPhost.length() ? UDPhost + ":" : "";
 					sourceOptions += UDPport;
 				} else {
 					ui->leSourceTCPPort->setEnabled(true);

--- a/ccx-options.h
+++ b/ccx-options.h
@@ -36,6 +36,10 @@ private slots:
 	void on_cbMultiprogram_toggled(bool checked);
 	void on_rbMultiprogramNumber_toggled(bool checked);
 	void on_btnOutputPath_clicked();
+	void on_cbTranslate_toggled(bool checked);
+	void on_cbMKVLang_toggled(bool checked);
+	void on_cbOCRName_toggled(bool checked);
+	void on_buttonOCRName_clicked();
 	void on_cbTeletextPage_toggled(bool checked);
 	void on_cbEnableStartCredits_toggled(bool checked);
 	void on_cbEnableEndCredits_toggled(bool checked);
@@ -46,6 +50,15 @@ private slots:
 	void on_btnOutputCapFile_clicked();
 	void on_cbOutputCapFile_toggled(bool checked);
 	void on_cbOutputDefaultColor_toggled(bool checked);
+	void on_cbInputType_currentIndexChanged(int index);
+	void on_cbNoLeven_toggled(bool checked);
+	void on_cbMinNum_toggled(bool checked);
+	void on_cbMaxPct_toggled(bool checked);
+	void on_cbEnableSharing_toggled(bool checked);
+	void on_cbOutputFont_toggled(bool checked);
+	void on_btnOutputFont_clicked();
+	void on_cbXMLTV_toggled(bool checked);
+	void on_cbXMLTVInterval_toggled(bool checked);
 	void on_cbOutputType_currentIndexChanged(int index);
 	void on_cbOutputTrim_toggled(bool checked);
 	void on_cbOutputInterval_toggled(bool checked);

--- a/ccx-options.ui
+++ b/ccx-options.ui
@@ -36,13 +36,13 @@ QGroupBox::title {
    <property name="geometry">
     <rect>
      <x>0</x>
-     <y>10</y>
+     <y>0</y>
      <width>741</width>
      <height>431</height>
     </rect>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>4</number>
    </property>
    <widget class="QWidget" name="tabInput">
     <attribute name="title">
@@ -255,9 +255,9 @@ QGroupBox::title {
     <widget class="QGroupBox" name="gbMythTV">
      <property name="geometry">
       <rect>
-       <x>430</x>
+       <x>420</x>
        <y>130</y>
-       <width>301</width>
+       <width>201</width>
        <height>111</height>
       </rect>
      </property>
@@ -312,7 +312,7 @@ QGroupBox::title {
       <rect>
        <x>100</x>
        <y>130</y>
-       <width>321</width>
+       <width>311</width>
        <height>111</height>
       </rect>
      </property>
@@ -324,7 +324,7 @@ QGroupBox::title {
        <rect>
         <x>10</x>
         <y>20</y>
-        <width>301</width>
+        <width>291</width>
         <height>92</height>
        </rect>
       </property>
@@ -349,6 +349,16 @@ QGroupBox::title {
          </property>
          <property name="checked">
           <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="rbMultiprogram">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Process all suitable programs</string>
          </property>
         </widget>
        </item>
@@ -544,6 +554,48 @@ QGroupBox::title {
       </layout>
      </widget>
     </widget>
+    <widget class="QGroupBox" name="gbPTSJumps">
+     <property name="geometry">
+      <rect>
+       <x>630</x>
+       <y>130</y>
+       <width>101</width>
+       <height>111</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>PTS Jumps</string>
+     </property>
+     <widget class="QRadioButton" name="rbPTSDefault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>30</y>
+        <width>81</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Ignore jumps</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="rbPTSFix">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>70</y>
+        <width>81</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Fix jumps</string>
+      </property>
+     </widget>
+    </widget>
    </widget>
    <widget class="QWidget" name="tabInput2">
     <attribute name="title">
@@ -566,7 +618,7 @@ QGroupBox::title {
        <rect>
         <x>10</x>
         <y>20</y>
-        <width>631</width>
+        <width>451</width>
         <height>232</height>
        </rect>
       </property>
@@ -595,7 +647,7 @@ QGroupBox::title {
        <item>
         <widget class="QCheckBox" name="cbMiscWTV">
          <property name="text">
-          <string>Work around a bug in Windows 7's built in software when converted from *.wtv to *.dvr-ms</string>
+          <string>Work around a bug in Windows 7 converting from *.wtv to *.dvr-ms</string>
          </property>
         </widget>
        </item>
@@ -686,7 +738,7 @@ QGroupBox::title {
       <rect>
        <x>10</x>
        <y>0</y>
-       <width>721</width>
+       <width>161</width>
        <height>131</height>
       </rect>
      </property>
@@ -699,7 +751,7 @@ QGroupBox::title {
         <x>10</x>
         <y>20</y>
         <width>631</width>
-        <height>101</height>
+        <height>111</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -739,6 +791,225 @@ QGroupBox::title {
         </widget>
        </item>
       </layout>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbSubtitle">
+     <property name="geometry">
+      <rect>
+       <x>179</x>
+       <y>-1</y>
+       <width>551</width>
+       <height>131</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>Subtitles</string>
+     </property>
+     <widget class="QWidget" name="horizontalLayoutWidget_11">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>261</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_17">
+       <item>
+        <widget class="QCheckBox" name="cbDVBLang">
+         <property name="text">
+          <string>Select DVB language</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="leDVBLang"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="horizontalLayoutWidget_12">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>100</y>
+        <width>531</width>
+        <height>25</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_18">
+       <item>
+        <widget class="QCheckBox" name="cbOCRName">
+         <property name="text">
+          <string>Select OCR file name</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="leOCRName"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="buttonOCRName">
+         <property name="text">
+          <string>Browse</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QGroupBox" name="gbQuant">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>211</width>
+        <height>61</height>
+       </rect>
+      </property>
+      <property name="title">
+       <string>Quantization</string>
+      </property>
+      <widget class="QRadioButton" name="rbQuantNone">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>20</y>
+         <width>71</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>None</string>
+       </property>
+      </widget>
+      <widget class="QRadioButton" name="rbQuantDefault">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>40</y>
+         <width>81</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>CCExtractor</string>
+       </property>
+      </widget>
+      <widget class="QRadioButton" name="rbQuantLess">
+       <property name="geometry">
+        <rect>
+         <x>100</x>
+         <y>20</y>
+         <width>101</width>
+         <height>31</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Fast (less colors)</string>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="horizontalLayoutWidget_13">
+      <property name="geometry">
+       <rect>
+        <x>280</x>
+        <y>20</y>
+        <width>261</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_19">
+       <item>
+        <widget class="QCheckBox" name="cbMKVLang">
+         <property name="text">
+          <string>Select MKV language</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="leMKVLang"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QGroupBox" name="gbOEM">
+      <property name="geometry">
+       <rect>
+        <x>230</x>
+        <y>40</y>
+        <width>141</width>
+        <height>61</height>
+       </rect>
+      </property>
+      <property name="title">
+       <string>OEM Mode</string>
+      </property>
+      <widget class="QRadioButton" name="rbOEMDefault">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>20</y>
+         <width>82</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Tesseract</string>
+       </property>
+      </widget>
+      <widget class="QRadioButton" name="rbOEMLSTM">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>40</y>
+         <width>82</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>LSTM</string>
+       </property>
+      </widget>
+      <widget class="QRadioButton" name="rbOEMBoth">
+       <property name="geometry">
+        <rect>
+         <x>90</x>
+         <y>20</y>
+         <width>101</width>
+         <height>31</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Both</string>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QCheckBox" name="cbNoSpupngocr">
+      <property name="geometry">
+       <rect>
+        <x>390</x>
+        <y>60</y>
+        <width>151</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label">
+      <property name="geometry">
+       <rect>
+        <x>416</x>
+        <y>49</y>
+        <width>121</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>When processing DVB, don't use OCR for comments in the XML file.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
      </widget>
     </widget>
    </widget>
@@ -1234,6 +1505,22 @@ QGroupBox::title {
       </property>
      </widget>
     </widget>
+    <widget class="QCheckBox" name="cbTickerTape">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="geometry">
+      <rect>
+       <x>160</x>
+       <y>280</y>
+       <width>281</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Search for burned-in text at the bottom of the screen</string>
+     </property>
+    </widget>
    </widget>
    <widget class="QWidget" name="tabDebug">
     <attribute name="title">
@@ -1245,21 +1532,21 @@ QGroupBox::title {
        <x>10</x>
        <y>10</y>
        <width>721</width>
-       <height>402</height>
+       <height>372</height>
       </rect>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
+      <item row="7" column="0">
+       <widget class="QCheckBox" name="cbDebugFullBin">
+        <property name="text">
+         <string>FullBin (Disable removal of trailing padding blocks when exporting to bin)</string>
+        </property>
+       </widget>
+      </item>
       <item row="6" column="0">
        <widget class="QCheckBox" name="cbDebugNoSync">
         <property name="text">
          <string>NoSync (Disable the syncing code. Only useful for debugging purposes.)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QCheckBox" name="cbDebugFullBin">
-        <property name="text">
-         <string>FullBin (Disable the removal of trailing padding blocks when exporting to bin format)</string>
         </property>
        </widget>
       </item>
@@ -1273,7 +1560,7 @@ QGroupBox::title {
       <item row="8" column="0">
        <widget class="QCheckBox" name="cbDebugParse">
         <property name="text">
-         <string>Parse (Print debug info about the parsed container file. Only for TS/ASF files at the moment.)</string>
+         <string>Parse (Print debug info about the parsed container file for TS/ASF files.)</string>
         </property>
        </widget>
       </item>
@@ -1291,13 +1578,6 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
-      <item row="11" column="0">
-       <widget class="QCheckBox" name="cbDebugInvestigate">
-        <property name="text">
-         <string>Investigate packets (If no CC packets are detected using the PMT, try to find data in all packets by scanning)</string>
-        </property>
-       </widget>
-      </item>
       <item row="10" column="0">
        <widget class="QCheckBox" name="cbDebugPMT">
         <property name="text">
@@ -1305,10 +1585,24 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
+      <item row="11" column="0">
+       <widget class="QCheckBox" name="cbDebugInvestigate">
+        <property name="text">
+         <string>Investigate packets (Find data in all packets by scanning w/o PMT)</string>
+        </property>
+       </widget>
+      </item>
       <item row="9" column="0">
        <widget class="QCheckBox" name="cbDebugPAT">
         <property name="text">
          <string>PAT (Print Program Association Table dump)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="cbDebug708">
+        <property name="text">
+         <string>708 (Print debug information from the EIA-708 (DTV) decoder)</string>
         </property>
        </widget>
       </item>
@@ -1333,14 +1627,7 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="cbDebug708">
-        <property name="text">
-         <string>708 (Print debug information from the EIA-708 (DTV) decoder)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="14" column="0">
+      <item row="15" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_13">
         <item>
          <widget class="QCheckBox" name="cbDebugESFile">
@@ -1375,6 +1662,41 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="cbDebugDVBSUB">
+        <property name="text">
+         <string>Write DVB subtitle debug traces to console.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="14" column="0">
+       <widget class="QCheckBox" name="cbPESHeader">
+        <property name="text">
+         <string>Dump the PES header to stdout (debug packet headers)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="cbDeblev">
+        <property name="text">
+         <string>Show calculated distance between strings for typo correction</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="cbAnvid">
+        <property name="text">
+         <string>Analyze the video stream for video information</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="cbSharingDebug">
+        <property name="text">
+         <string>Print extracted CC sharing service messages</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </widget>
@@ -1388,7 +1710,7 @@ QGroupBox::title {
        <x>10</x>
        <y>0</y>
        <width>721</width>
-       <height>121</height>
+       <height>131</height>
       </rect>
      </property>
      <property name="title">
@@ -1489,6 +1811,34 @@ QGroupBox::title {
          </property>
         </widget>
        </item>
+       <item row="3" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_20">
+         <item>
+          <widget class="QLineEdit" name="leOutputFont">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnOutputFont">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Browse</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="cbOutputFont">
+         <property name="text">
+          <string>Font filename</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>
@@ -1496,7 +1846,7 @@ QGroupBox::title {
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>130</y>
+       <y>140</y>
        <width>121</width>
        <height>81</height>
       </rect>
@@ -1551,7 +1901,7 @@ QGroupBox::title {
      <property name="geometry">
       <rect>
        <x>140</x>
-       <y>130</y>
+       <y>140</y>
        <width>191</width>
        <height>80</height>
       </rect>
@@ -1593,7 +1943,7 @@ QGroupBox::title {
      <property name="geometry">
       <rect>
        <x>340</x>
-       <y>130</y>
+       <y>140</y>
        <width>391</width>
        <height>81</height>
       </rect>
@@ -1655,9 +2005,9 @@ QGroupBox::title {
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>220</y>
-       <width>361</width>
-       <height>171</height>
+       <y>230</y>
+       <width>381</width>
+       <height>161</height>
       </rect>
      </property>
      <property name="title">
@@ -1721,10 +2071,10 @@ QGroupBox::title {
       </property>
       <property name="geometry">
        <rect>
-        <x>200</x>
+        <x>150</x>
         <y>140</y>
         <width>81</width>
-        <height>25</height>
+        <height>20</height>
        </rect>
       </property>
      </widget>
@@ -1745,10 +2095,10 @@ QGroupBox::title {
     <widget class="QGroupBox" name="gbOutputTranscript">
      <property name="geometry">
       <rect>
-       <x>380</x>
-       <y>220</y>
-       <width>351</width>
-       <height>171</height>
+       <x>400</x>
+       <y>230</y>
+       <width>331</width>
+       <height>161</height>
       </rect>
      </property>
      <property name="title">
@@ -1786,9 +2136,9 @@ QGroupBox::title {
      <widget class="QLineEdit" name="leOutputTranscriptUnixRef">
       <property name="geometry">
        <rect>
-        <x>190</x>
+        <x>150</x>
         <y>20</y>
-        <width>151</width>
+        <width>161</width>
         <height>25</height>
        </rect>
       </property>
@@ -1846,7 +2196,7 @@ QGroupBox::title {
       <rect>
        <x>10</x>
        <y>200</y>
-       <width>721</width>
+       <width>491</width>
        <height>191</height>
       </rect>
      </property>
@@ -1858,7 +2208,7 @@ QGroupBox::title {
        <rect>
         <x>10</x>
         <y>20</y>
-        <width>271</width>
+        <width>265</width>
         <height>191</height>
        </rect>
       </property>
@@ -1928,13 +2278,60 @@ QGroupBox::title {
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="verticalLayoutWidget_9">
+      <property name="geometry">
+       <rect>
+        <x>279</x>
+        <y>19</y>
+        <width>216</width>
+        <height>171</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_9">
+       <item>
+        <widget class="QCheckBox" name="cbChapters">
+         <property name="text">
+          <string>Produce a chapter file for MP4</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbAppend">
+         <property name="text">
+          <string>Append to output files</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbWebvttCSS">
+         <property name="text">
+          <string>Create separate CSS file for WebVTT</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbSegmentKey">
+         <property name="text">
+          <string>Segment output only after I frames</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbSplitSentence">
+         <property name="text">
+          <string>Split output text by complete sentences</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
     <widget class="QGroupBox" name="gbOutputTranscript2">
      <property name="geometry">
       <rect>
        <x>10</x>
        <y>0</y>
-       <width>721</width>
+       <width>391</width>
        <height>191</height>
       </rect>
      </property>
@@ -1963,9 +2360,9 @@ QGroupBox::title {
       </property>
       <property name="geometry">
        <rect>
-        <x>150</x>
+        <x>170</x>
         <y>10</y>
-        <width>281</width>
+        <width>221</width>
         <height>181</height>
        </rect>
       </property>
@@ -1980,7 +2377,7 @@ QGroupBox::title {
         <rect>
          <x>10</x>
          <y>20</y>
-         <width>271</width>
+         <width>221</width>
          <height>157</height>
         </rect>
        </property>
@@ -2042,6 +2439,299 @@ QGroupBox::title {
         </item>
        </layout>
       </widget>
+     </widget>
+     <widget class="QCheckBox" name="cbOutputXDS">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>151</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Save XDS info to transcript</string>
+      </property>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbLevenshtein">
+     <property name="geometry">
+      <rect>
+       <x>409</x>
+       <y>-1</y>
+       <width>321</width>
+       <height>101</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>Typo Correction</string>
+     </property>
+     <widget class="QCheckBox" name="cbNoLeven">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>171</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>No typo correction</string>
+      </property>
+     </widget>
+     <widget class="QWidget" name="formLayoutWidget_3">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>305</width>
+        <height>51</height>
+       </rect>
+      </property>
+      <layout class="QFormLayout" name="formLayout_6">
+       <item row="0" column="0">
+        <widget class="QCheckBox" name="cbMinNum">
+         <property name="text">
+          <string>Minimum allowed difference w/o correction</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="cbMaxPct">
+         <property name="text">
+          <string>Maximum difference percentage w/ correction</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="leMinNum">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="leMaxPct">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbTranslate">
+     <property name="geometry">
+      <rect>
+       <x>410</x>
+       <y>110</y>
+       <width>321</width>
+       <height>80</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>Translation</string>
+     </property>
+     <widget class="QCheckBox" name="cbTranslate">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>91</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string> Translate to:</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="leTranslate">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>100</x>
+        <y>20</y>
+        <width>211</width>
+        <height>20</height>
+       </rect>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_2">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>50</y>
+        <width>81</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Authentication:</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="leTranslateAuth">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>90</x>
+        <y>50</y>
+        <width>221</width>
+        <height>20</height>
+       </rect>
+      </property>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbSharing">
+     <property name="geometry">
+      <rect>
+       <x>510</x>
+       <y>200</y>
+       <width>221</width>
+       <height>91</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>Sharing</string>
+     </property>
+     <widget class="QCheckBox" name="cbEnableSharing">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>269</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Enable sharing</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="lblEnableSharing">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>71</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Sharing URL:</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="leEnableSharing">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>60</y>
+        <width>201</width>
+        <height>20</height>
+       </rect>
+      </property>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbXMLTV">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="geometry">
+      <rect>
+       <x>510</x>
+       <y>300</y>
+       <width>221</width>
+       <height>91</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>XMLTV</string>
+     </property>
+     <widget class="QRadioButton" name="rbXMLTVFull">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>82</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Full file</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="rbXMLTVLive">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>82</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Live file</string>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="rbXMLTVBoth">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>60</y>
+        <width>82</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Both files</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="cbXMLTVCurrent">
+      <property name="geometry">
+       <rect>
+        <x>80</x>
+        <y>20</y>
+        <width>141</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Only print current events</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="cbXMLTVInterval">
+      <property name="geometry">
+       <rect>
+        <x>80</x>
+        <y>40</y>
+        <width>121</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Output at interval:</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="leXMLTVInterval">
+      <property name="geometry">
+       <rect>
+        <x>80</x>
+        <y>60</y>
+        <width>131</width>
+        <height>20</height>
+       </rect>
+      </property>
      </widget>
     </widget>
    </widget>


### PR DESCRIPTION
Added a variety of options that were missing from the previous build.

**Changes**
Main window:
- Fixed bug that didn't include a ":" in the UDP address

Options window:
- Added Matroska/WebM, MXF to the input types (-in=mkv, mxf)
- Added Grid 608, curl, TCP output types (-out=g608, curl, bin (w/ -sendto))
- Added -multiprogram and -fixptsjumps to the "Input" page
- Added -dvblang, -ocrlang, -quant, -nospupngocr, -oem, and -mkvlang to the "Input (2)" page
- Added -pesheader, -debugdvbsub, -deblev, -anvid, and -sharing-debug to the "Debug" page
- Added -unicode to the possible encodings on the "Output" page
- Added -sendto and -curlposturl support via the Output "Path" input
- Added -font, -xmltv <mode>, -xmltvfullinterval, -xmltvliveinterval, -xds, -chapters, --append, --webvtt-create-css, -key, --splitbysentence, --nolevdist, -levdistmincnt, -levdistmaxpct, -enable-sharing/-sharing-url, -translate/-translate-auth to the "Output (2) page
- Fixed bug that allowed buffer size to be specified even with the no buffering requirement
- Added -tickertext to the "Burned-in" page